### PR TITLE
Default orientation Bug

### DIFF
--- a/src/pybullet_industrial/interpolation.py
+++ b/src/pybullet_industrial/interpolation.py
@@ -52,7 +52,9 @@ def linear_interpolation(start_point: np.array, end_point: np.array, samples: in
     positions = np.linspace(start_point, end_point, num=samples)
     final_path = ToolPath(positions=positions.transpose())
 
-    if start_orientation is not None and end_orientation is not None:
+    if start_orientation is not None:
+        if end_orientation is None:
+            end_orientation = start_orientation
         start_orientation = p.getEulerFromQuaternion(start_orientation)
         end_orientation = p.getEulerFromQuaternion(end_orientation)
         orientations = np.linspace(start_orientation,
@@ -148,7 +150,9 @@ def circular_interpolation(start_point: np.array, end_point: np.array,
     positions[axis] = np.linspace(start_point[axis], end_point[axis], samples)
     final_path = ToolPath(positions=positions)
 
-    if start_orientation is not None and end_orientation is not None:
+    if start_orientation is not None:
+        if end_orientation is None:
+            end_orientation = start_orientation
         start_orientation = p.getEulerFromQuaternion(start_orientation)
         end_orientation = p.getEulerFromQuaternion(end_orientation)
         orientations = np.linspace(start_orientation,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates both the `linear_interpolation` and `circular_interpolation` functions to handle cases where `end_orientation` is not provided. In both functions, `end_orientation` now defaults to `start_orientation` when not specified. This ensures that if only the starting orientation is provided, the object maintains a consistent orientation along the interpolated path, preventing potential misbehavior.

## Motivation and Context
Previously, if `end_orientation` was omitted, the behavior could be unclear or could require additional handling by the user. By defaulting to `start_orientation`, the functions now behave more predictably and simplify cases where orientation remains constant. This enhancement improves both usability and robustness in path generation.

## How has this been tested?
- The changes were tested running the interpolation demonstration class 

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.